### PR TITLE
Replace simp; omega patterns with grind

### DIFF
--- a/Urm/Composition/Core.lean
+++ b/Urm/Composition/Core.lean
@@ -92,7 +92,7 @@ theorem transfer_results_to_inputs_writes_to (resultStart arityF : ℕ)
 theorem transfer_results_to_inputs_preserves_outside (resultStart arityF : ℕ) (r : ℕ) (hr : r ≥ arityF) :
     ∀ instr, instr ∈ Program.transfer_results_to_inputs resultStart arityF → instr.writes_to ≠ some r := by
   intro instr hinstr; obtain ⟨i, hi, hwrites⟩ := transfer_results_to_inputs_writes_to resultStart arityF instr hinstr
-  rw [hwrites]; simp only [ne_eq, Option.some.injEq]; omega
+  rw [hwrites]; grind
 
 section Continuation
 
@@ -134,21 +134,21 @@ theorem Steps.of_concat_right {s : State} {c' : Config}
   | refl =>
     refine ⟨⟨c''.pc - p1.length, c''.state⟩, Relation.ReflTransGen.refl, ?_, rfl⟩
     simp only [Config.is_halted] at hhalted' ⊢
-    simp only [Program.concat, List.length_append, Program.shift_jumps, List.length_map] at hhalted'; omega
+    simp only [Program.concat, List.length_append, Program.shift_jumps, List.length_map] at hhalted'; grind
   | @head a b hstep hrest ih =>
     have ha_in_range : a.pc < p1.length + p2.length := by
       by_contra hc; simp only [not_lt] at hc
-      exact Step.no_step_of_halted (by simp only [Config.is_halted, Program.concat, List.length_append, Program.shift_jumps, List.length_map]; omega) hstep
+      exact Step.no_step_of_halted (by simp only [Config.is_halted, Program.concat, List.length_append, Program.shift_jumps, List.length_map]; grind) hstep
     have hstep_p2 := Step.of_concat_right hstart ha_in_range hstep
     have hb_pc_ge : b.pc ≥ p1.length := by
       cases hstep with
-      | zero _ | succ _ | trans _ | jump_ne _ _ => simp only []; omega
+      | zero _ | succ _ | trans _ | jump_ne _ _ => grind
       | jump_eq h _ =>
         rw [Program.getElem?_concat_of_ge a.pc hstart, Program.getElem?_shift_jumps] at h
         cases hp2 : p2[a.pc - p1.length]? with
         | none => simp only [hp2, Option.map_none] at h; nomatch h
         | some instr => simp only [hp2, Option.map_some] at h; cases instr with
-          | J _ _ q' => simp only [Instr.shift_jumps, Option.some.injEq, Instr.J.injEq] at h; obtain ⟨_, _, hq_eq⟩ := h; simp only [← hq_eq]; omega
+          | J _ _ q' => simp only [Instr.shift_jumps, Option.some.injEq, Instr.J.injEq] at h; obtain ⟨_, _, hq_eq⟩ := h; grind
           | _ => simp only [Instr.shift_jumps, Option.some.injEq] at h; nomatch h
     obtain ⟨c, hrest_p2, hhalted_c, hstate_eq⟩ := ih hb_pc_ge
     exact ⟨c, Relation.ReflTransGen.head hstep_p2 hrest_p2, hhalted_c, hstate_eq⟩
@@ -158,7 +158,7 @@ theorem suffix_of_concat_from_zero {p1 p2 : Program} {s : State} {c : Config}
     ∃ s', Steps p1 ⟨0, s⟩ ⟨p1.length, s'⟩ ∧ (∃ c', Steps p2 ⟨0, s'⟩ c' ∧ c'.is_halted p2) := by
   obtain ⟨c1, hsteps_p1, hhalted_p1⟩ := prefix_of_concat_from_zero hsteps hhalted h1
   have hc1_le := h1.pc_le_length hsteps_p1 (by simp : (⟨0, s⟩ : Config).pc ≤ p1.length)
-  have hc1_pc : c1.pc = p1.length := by simp only [Config.is_halted] at hhalted_p1; omega
+  have hc1_pc : c1.pc = p1.length := by simp only [Config.is_halted] at hhalted_p1; grind
   refine ⟨c1.state, ?_, ?_⟩
   · convert hsteps_p1 using 1; ext <;> simp [hc1_pc]
   · have hsteps_p1_lifted : Steps (p1.concat p2) ⟨0, s⟩ ⟨p1.length, c1.state⟩ := by

--- a/Urm/Concat.lean
+++ b/Urm/Concat.lean
@@ -159,15 +159,15 @@ theorem Step.concat_right {c c' : Config}
   | .zero (n := n) h =>
     have h' : (p1.concat p2)[c.pc + p1.length]? = some (Instr.Z n) := by
       rw [hinstr_eq, Program.getElem?_shift_jumps, h]; rfl
-    convert @Step.zero (p1.concat p2) ⟨c.pc + p1.length, c.state⟩ n h' using 2; simp; omega
+    convert @Step.zero (p1.concat p2) ⟨c.pc + p1.length, c.state⟩ n h' using 2; grind
   | .succ (n := n) h =>
     have h' : (p1.concat p2)[c.pc + p1.length]? = some (Instr.S n) := by
       rw [hinstr_eq, Program.getElem?_shift_jumps, h]; rfl
-    convert @Step.succ (p1.concat p2) ⟨c.pc + p1.length, c.state⟩ n h' using 2; simp; omega
+    convert @Step.succ (p1.concat p2) ⟨c.pc + p1.length, c.state⟩ n h' using 2; grind
   | .trans (m := m) (n := n) h =>
     have h' : (p1.concat p2)[c.pc + p1.length]? = some (Instr.T m n) := by
       rw [hinstr_eq, Program.getElem?_shift_jumps, h]; rfl
-    convert @Step.trans (p1.concat p2) ⟨c.pc + p1.length, c.state⟩ m n h' using 2; simp; omega
+    convert @Step.trans (p1.concat p2) ⟨c.pc + p1.length, c.state⟩ m n h' using 2; grind
   | .jump_eq (m := m) (n := n) (q := q) h heq =>
     have h' : (p1.concat p2)[c.pc + p1.length]? = some (Instr.J m n (q + p1.length)) := by
       rw [hinstr_eq, Program.getElem?_shift_jumps, h]; rfl
@@ -175,7 +175,7 @@ theorem Step.concat_right {c c' : Config}
   | .jump_ne (m := m) (n := n) (q := q) h hne =>
     have h' : (p1.concat p2)[c.pc + p1.length]? = some (Instr.J m n (q + p1.length)) := by
       rw [hinstr_eq, Program.getElem?_shift_jumps, h]; rfl
-    convert @Step.jump_ne (p1.concat p2) ⟨c.pc + p1.length, c.state⟩ m n (q + p1.length) h' hne using 2; simp; omega
+    convert @Step.jump_ne (p1.concat p2) ⟨c.pc + p1.length, c.state⟩ m n (q + p1.length) h' hne using 2; grind
 
 /-- Multi-step in the second part of a concatenated program. -/
 theorem Steps.concat_right {c c' : Config}

--- a/Urm/Minimization/Base.lean
+++ b/Urm/Minimization/Base.lean
@@ -29,25 +29,25 @@ namespace Urm
 open Program
 
 /-- The base register for minimization, ensuring pF doesn't clobber saved registers. -/
-def minimization_base (n : ℕ) (pF : Program) : ℕ :=
+@[grind =] def minimization_base (n : ℕ) (pF : Program) : ℕ :=
   max n pF.max_register
 
 /-- The register where counter y is stored. -/
-def counter_reg (n : ℕ) (pF : Program) : ℕ :=
+@[grind =] def counter_reg (n : ℕ) (pF : Program) : ℕ :=
   minimization_base n pF + n + 1
 
 /-- The zero register (always contains 0, used for J comparisons). -/
-def zero_reg (n : ℕ) (pF : Program) : ℕ :=
+@[grind =] def zero_reg (n : ℕ) (pF : Program) : ℕ :=
   minimization_base n pF + n + 2
 
 /-- The start of saved input registers. -/
-def savedInputsStart (n : ℕ) (pF : Program) : ℕ :=
+@[grind =] def savedInputsStart (n : ℕ) (pF : Program) : ℕ :=
   minimization_base n pF + 1
 
 /-- Tactic for solving register arithmetic goals in minimization.
-    Unfolds register definitions and calls omega. -/
+    Unfolds register definitions and calls grind. -/
 macro "min_register_omega" : tactic =>
-  `(tactic| (simp only [savedInputsStart, counter_reg, zero_reg, minimization_base]; omega))
+  `(tactic| grind)
 
 /-! ## Bound lemmas for minimization_base -/
 

--- a/Urm/PrimitiveRecursion/Base.lean
+++ b/Urm/PrimitiveRecursion/Base.lean
@@ -41,36 +41,35 @@ open Program
 /-- The base register for primitive recursion, ensuring neither pF nor pG
     clobbers saved registers, and saved registers don't overlap with pG's
     input space (registers 0 through n+1). -/
-def primitive_recursion_base (n : ℕ) (pF pG : Program) : ℕ :=
+@[grind =] def primitive_recursion_base (n : ℕ) (pF pG : Program) : ℕ :=
   max (n + 1) (max pF.max_register pG.max_register)
 
 /-! ## Register indices -/
 
 /-- The start of saved input registers R[base+1..base+n]. -/
-def pr_saved_inputs_start (n : ℕ) (pF pG : Program) : ℕ :=
+@[grind =] def pr_saved_inputs_start (n : ℕ) (pF pG : Program) : ℕ :=
   primitive_recursion_base n pF pG + 1
 
 /-- The register storing the original y value (recursion depth). -/
-def pr_saved_y_reg (n : ℕ) (pF pG : Program) : ℕ :=
+@[grind =] def pr_saved_y_reg (n : ℕ) (pF pG : Program) : ℕ :=
   primitive_recursion_base n pF pG + n + 1
 
 /-- The counter register (tracks current iteration 0..y). -/
-def pr_counter_reg (n : ℕ) (pF pG : Program) : ℕ :=
+@[grind =] def pr_counter_reg (n : ℕ) (pF pG : Program) : ℕ :=
   primitive_recursion_base n pF pG + n + 2
 
 /-- The accumulator register (holds result from previous iteration). -/
-def pr_accumulator_reg (n : ℕ) (pF pG : Program) : ℕ :=
+@[grind =] def pr_accumulator_reg (n : ℕ) (pF pG : Program) : ℕ :=
   primitive_recursion_base n pF pG + n + 3
 
 /-- The zero register (always 0, used for J comparisons). -/
-def pr_zero_reg (n : ℕ) (pF pG : Program) : ℕ :=
+@[grind =] def pr_zero_reg (n : ℕ) (pF pG : Program) : ℕ :=
   primitive_recursion_base n pF pG + n + 4
 
 /-- Tactic for solving register arithmetic goals in primitive recursion.
-    Unfolds register definitions and calls omega. -/
+    Unfolds register definitions and calls grind. -/
 macro "pr_register_omega" : tactic =>
-  `(tactic| (simp only [pr_saved_inputs_start, pr_saved_y_reg, pr_counter_reg,
-      pr_accumulator_reg, pr_zero_reg, primitive_recursion_base]; omega))
+  `(tactic| grind)
 
 /-! ## Bound lemmas for primitive_recursion_base -/
 

--- a/Urm/Simulate/EncodedStep.lean
+++ b/Urm/Simulate/EncodedStep.lean
@@ -251,7 +251,7 @@ private theorem encoded_step_correct_zero (p : Program) (c : Config) (n : ℕ)
     simp only [Instr.max_register] at h
     exact h
   simp only [hn, ↓reduceIte]
-  rw [update_nth_encoded_encode_regs _ _ _ (by simp; omega)]
+  rw [update_nth_encoded_encode_regs _ _ _ (by grind)]
   congr 1
   exact congrArg _ (ofFn_set_eq_ofFn_write p.max_register c n 0)
 
@@ -277,11 +277,11 @@ private theorem encoded_step_correct_succ (p : Program) (c : Config) (n : ℕ)
     simp only [Instr.max_register] at h
     exact h
   simp only [hn, ↓reduceIte]
-  rw [nth_encoded_encode_regs _ n (by simp; omega)]
-  rw [update_nth_encoded_encode_regs _ _ _ (by simp; omega)]
+  rw [nth_encoded_encode_regs _ n (by grind)]
+  rw [update_nth_encoded_encode_regs _ _ _ (by grind)]
   congr 1
-  have heq1 : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[n]'(by simp; omega) =
-      c.state n := ofFn_getElem p.max_register c n (by omega)
+  have heq1 : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[n]'(by grind) =
+      c.state n := ofFn_getElem p.max_register c n (by grind)
   rw [heq1]
   simp only [State.read]
   exact congrArg _ (ofFn_set_eq_ofFn_write p.max_register c n (c.state n + 1))
@@ -307,11 +307,11 @@ private theorem encoded_step_correct_trans (p : Program) (c : Config) (m n : ℕ
   have hm : m ≤ p.max_register := le_of_max_le_left hmn
   have hn : n ≤ p.max_register := le_of_max_le_right hmn
   simp only [hn, hm, ↓reduceIte]
-  rw [nth_encoded_encode_regs _ m (by simp; omega)]
-  rw [update_nth_encoded_encode_regs _ _ _ (by simp; omega)]
+  rw [nth_encoded_encode_regs _ m (by grind)]
+  rw [update_nth_encoded_encode_regs _ _ _ (by grind)]
   congr 1
-  have heq1 : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[m]'(by simp; omega) =
-      c.state m := ofFn_getElem p.max_register c m (by omega)
+  have heq1 : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[m]'(by grind) =
+      c.state m := ofFn_getElem p.max_register c m (by grind)
   rw [heq1]
   simp only [State.read]
   exact congrArg _ (ofFn_set_eq_ofFn_write p.max_register c n (c.state m))
@@ -338,12 +338,12 @@ private theorem encoded_step_correct_jump_eq (p : Program) (c : Config) (m n q :
   have hm : m ≤ p.max_register := le_of_max_le_left hmn
   have hn : n ≤ p.max_register := le_of_max_le_right hmn
   simp only [hm, hn, ↓reduceIte]
-  rw [nth_encoded_encode_regs _ m (by simp; omega)]
-  rw [nth_encoded_encode_regs _ n (by simp; omega)]
-  have heqm : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[m]'(by simp; omega) =
-      c.state m := ofFn_getElem p.max_register c m (by omega)
-  have heqn : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[n]'(by simp; omega) =
-      c.state n := ofFn_getElem p.max_register c n (by omega)
+  rw [nth_encoded_encode_regs _ m (by grind)]
+  rw [nth_encoded_encode_regs _ n (by grind)]
+  have heqm : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[m]'(by grind) =
+      c.state m := ofFn_getElem p.max_register c m (by grind)
+  have heqn : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[n]'(by grind) =
+      c.state n := ofFn_getElem p.max_register c n (by grind)
   rw [heqm, heqn]
   simp only [State.read] at heq
   simp only [heq, ↓reduceIte]
@@ -370,12 +370,12 @@ private theorem encoded_step_correct_jump_ne (p : Program) (c : Config) (m n q :
   have hm : m ≤ p.max_register := le_of_max_le_left hmn
   have hn : n ≤ p.max_register := le_of_max_le_right hmn
   simp only [hm, hn, ↓reduceIte]
-  rw [nth_encoded_encode_regs _ m (by simp; omega)]
-  rw [nth_encoded_encode_regs _ n (by simp; omega)]
-  have heqm : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[m]'(by simp; omega) =
-      c.state m := ofFn_getElem p.max_register c m (by omega)
-  have heqn : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[n]'(by simp; omega) =
-      c.state n := ofFn_getElem p.max_register c n (by omega)
+  rw [nth_encoded_encode_regs _ m (by grind)]
+  rw [nth_encoded_encode_regs _ n (by grind)]
+  have heqm : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[m]'(by grind) =
+      c.state m := ofFn_getElem p.max_register c m (by grind)
+  have heqn : (List.ofFn (fun j : Fin (p.max_register + 1) => c.state j))[n]'(by grind) =
+      c.state n := ofFn_getElem p.max_register c n (by grind)
   rw [heqm, heqn]
   simp only [State.read] at hne
   simp only [hne, ↓reduceIte]

--- a/Urm/StraightLine.lean
+++ b/Urm/StraightLine.lean
@@ -102,7 +102,7 @@ theorem straight_line_halts_at_length {p : Program} (hsl : p.is_straight_line = 
     cases hstep with
     | zero hinstr | succ hinstr | trans hinstr =>
       have hpc_lt := List.getElem?_eq_some_iff.mp hinstr |>.1
-      simp only at ih ⊢; omega
+      grind
     | jump_eq hinstr _ | jump_ne hinstr _ =>
       have ⟨hlt, heq⟩ := List.getElem?_eq_some_iff.mp hinstr
       simp only [Program.is_straight_line, List.all_eq_true] at hsl
@@ -249,7 +249,7 @@ theorem straight_line_zeros_register {p : Program} (hsl : p.is_straight_line = t
     have ha'_pc_lt := Step.pc_lt_length hstep
     have hc'_pc_gt : c'.pc > k := by
       cases hstep with
-      | zero _ | succ _ | trans _ | jump_ne _ _ => simp only []; omega
+      | zero _ | succ _ | trans _ | jump_ne _ _ => grind
       | jump_eq h heq =>
         simp only [Program.is_straight_line, List.all_eq_true] at hsl
         exact absurd (hsl _ ((List.getElem?_eq_some_iff.mp h).2 ▸ List.getElem_mem ha'_pc_lt)) (by simp [Instr.is_non_jumping])
@@ -350,11 +350,11 @@ theorem copy_register_range_length (srcStart dstStart count : ℕ) :
 
 /-- Tactic for solving length arithmetic goals involving clear_registers and copy_register_range. -/
 macro "len_append_omega" : tactic =>
-  `(tactic| (simp only [List.length_append, clear_registers_length, copy_register_range_length]; omega))
+  `(tactic| (simp only [List.length_append, clear_registers_length, copy_register_range_length]; grind))
 
 /-- Tactic for proving register write targets are distinct. -/
 macro "writes_to_omega" : tactic =>
-  `(tactic| (simp only [Instr.writes_to, ne_eq, Option.some.injEq]; omega))
+  `(tactic| (simp only [Instr.writes_to, ne_eq, Option.some.injEq]; grind))
 
 @[scoped grind =]
 theorem clear_registers_is_straight_line (maxReg : ℕ) :
@@ -379,7 +379,7 @@ theorem copy_register_range_preserves_outside (srcStart dstStart count : ℕ)
     (r : ℕ) (hr : r < dstStart ∨ r ≥ dstStart + count) :
     ∀ instr, instr ∈ Program.copy_register_range srcStart dstStart count → instr.writes_to ≠ some r := by
   intro instr hinstr; obtain ⟨i, hi, hwrites⟩ := copy_register_range_writes_to srcStart dstStart count instr hinstr
-  rw [hwrites]; simp only [ne_eq, Option.some.injEq]; omega
+  rw [hwrites]; grind
 
 /-- clear_registers preserves registers above maxReg. -/
 theorem clear_registers_preserves_above (maxReg : ℕ) (s : State) (r : ℕ) (hr : r > maxReg) :
@@ -431,7 +431,7 @@ theorem straight_line_transfer_result {p : Program} (hsl : p.is_straight_line = 
     have ha'_pc_lt := Step.pc_lt_length hstep
     have hc'_pc_gt : c'.pc > k := by
       cases hstep with
-      | zero _ | succ _ | trans _ | jump_ne _ _ => simp only []; omega
+      | zero _ | succ _ | trans _ | jump_ne _ _ => grind
       | jump_eq h heq' =>
         simp only [Program.is_straight_line, List.all_eq_true] at hsl
         exact absurd (hsl _ ((List.getElem?_eq_some_iff.mp h).2 ▸ List.getElem_mem ha'_pc_lt)) (by simp [Instr.is_non_jumping])


### PR DESCRIPTION
## Summary
- Add `@[grind =]` annotations to register definitions so grind can unfold them
- Update custom tactics (`min_register_omega`, `pr_register_omega`, etc.) to use grind
- Replace ~33 occurrences of `simp; omega` with `grind` across 6 files

## Test plan
- [x] `lake build` passes